### PR TITLE
add missing dependency for babel to fix builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "oauth2-server": "^2.4.1",
     "redis": "^2.0.0",
     "socket.io": "1.3.7",
+    "to-iso-string": "0.0.2",
     "uuid": "2.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
babel apparently depends on to-iso-string, but fails to actually include the depedency.