### PR TITLE
swap agency.order and agency.search

### DIFF
--- a/src/oauth/configstore/dbc.js
+++ b/src/oauth/configstore/dbc.js
@@ -22,8 +22,8 @@ export default class DbcConfigStore extends InmemoryConfigStore {
           config.agency = {};
         }
 
-        config.agency.search = user.libraryId;
-        config.agency.order = config.agency.order || user.libraryId;
+        config.agency.order = user.libraryId;
+        config.agency.search = config.agency.search || user.libraryId;
 
         return config;
       });


### PR DESCRIPTION
agency.order and agency.search was swapped by mistake, which is now fixed.