### PR TITLE
return falsy client to oauth2-server when model.getClient fails, instead of error

### DIFF
--- a/src/__tests__/app.test.js
+++ b/src/__tests__/app.test.js
@@ -77,6 +77,20 @@ describe('web app', function () {
       .expect(400, done);
   });
 
+  it('should return an error when requesting a token with invalid client credentials', function (done) {
+    request(app)
+      .post('/oauth/token')
+      .auth('invalid', 'invalid')
+      .type('form')
+      .send({
+        grant_type: 'password',
+        username: userEncode(null, null),
+        password: userEncode(null, null)
+      })
+      .expect(400, done);
+  });
+
+
   it('should return a token when logging in as anonymous', function (done) {
     request(app)
       .post('/oauth/token')

--- a/src/oauth/twolevel.model.js
+++ b/src/oauth/twolevel.model.js
@@ -43,7 +43,7 @@ export class Model {
       })
       .catch((err) => {
         log.info('model.getClient failure', {clientId: clientId, err: err});
-        callback(err, false);
+        callback(null, false);
       });
   }
 


### PR DESCRIPTION
fixes #148 