### PR TITLE
implement per client userstore

### DIFF
--- a/src/__tests__/app.test.js
+++ b/src/__tests__/app.test.js
@@ -49,14 +49,15 @@ describe('web app', function () {
       }
     };
 
+    const defaultUserStore = new UserStore(stores);
+    defaultUserStore.storeUser(username, password);
     stores.clientStore = new ClientStore(stores);
     stores.tokenStore = new TokenStore(stores);
-    stores.userStore = new UserStore(stores);
     stores.configStore = new ConfigStore(stores, configStoreConfig);
     stores.clientStore.update(clientId, client);
-    stores.userStore.storeUser(username, password);
     app = createApp(appConfig);
     app.set('stores', stores);
+    app.set('auth', {default: defaultUserStore});
   });
 
   it('should respond with 200 on /', function (done) {

--- a/src/__tests__/app.test.js
+++ b/src/__tests__/app.test.js
@@ -7,6 +7,8 @@ import request from 'supertest';
 import {createApp} from '../expressapp';
 import TokenStore from '../oauth/tokenstore/inmemory';
 import UserStore from '../oauth/userstore/inmemory';
+import AllowAllUserStore from '../oauth/userstore/allow-all';
+import DenyAllUserStore from '../oauth/userstore/deny-all';
 import ConfigStore from '../oauth/configstore/inmemory';
 import ClientStore from '../oauth/clientstore/inmemory';
 import {userEncode} from '../utils';
@@ -18,7 +20,11 @@ describe('web app', function () {
   var app = null;
   var chance = null;
   var clientId = null;
+  var clientId2 = null;
+  var clientId3 = null;
   var client = null;
+  var client2 = null;
+  var client3 = null;
   var user = null;
   var username = null;
   var password = null;
@@ -30,7 +36,11 @@ describe('web app', function () {
   before(function () {
     chance = new Chance();
     clientId = chance.word({length: 10});
+    clientId2 = chance.word({length: 10});
+    clientId3 = chance.word({length: 10});
     client = {name: chance.word({length: 10}), secret: chance.string()};
+    client2 = {name: chance.word({length: 10}), secret: chance.string(), auth: 'allowAll'};
+    client3 = {name: chance.word({length: 10}), secret: chance.string(), auth: 'denyAll'};
     user = {id: chance.word({length: 10}), libraryId: '123456'};
     username = userEncode(user.libraryId, user.id);
     password = chance.string();
@@ -55,9 +65,11 @@ describe('web app', function () {
     stores.tokenStore = new TokenStore(stores);
     stores.configStore = new ConfigStore(stores, configStoreConfig);
     stores.clientStore.update(clientId, client);
+    stores.clientStore.update(clientId2, client2);
+    stores.clientStore.update(clientId3, client3);
     app = createApp(appConfig);
     app.set('stores', stores);
-    app.set('auth', {default: defaultUserStore});
+    app.set('auth', {default: defaultUserStore, allowAll: new AllowAllUserStore(), denyAll: new DenyAllUserStore()});
   });
 
   it('should respond with 200 on /', function (done) {
@@ -132,6 +144,20 @@ describe('web app', function () {
       .expect(200, done);
   });
 
+  it('should not return a token when given an invalid password', function (done) {
+    request(app)
+      .post('/oauth/token')
+      .auth(clientId, client.secret)
+      .type('form')
+      .send({
+        grant_type: 'password',
+        username: userEncode(user.libraryId, user.id),
+        password: 'wrong-password'
+      })
+      // TODO: This shouldn't be a '400', but the oauth-library is at fault here. Make it return the proper error code..
+      .expect(400, done);
+  });
+
   it('should return configuration when queried for it with a token', function(done) {
     request(app)
       .get('/configuration?token=' + bearerToken)
@@ -151,5 +177,38 @@ describe('web app', function () {
         returnedConfig.should.deep.equal(expected);
       })
       .expect(200, done);
+  });
+
+  it('should pick auth-backend based on the client id (allow all)', function(done) {
+    request(app)
+      .post('/oauth/token')
+      .auth(clientId2, client2.secret)
+      .type('form')
+      .send({
+        grant_type: 'password',
+        username: userEncode(user.libraryId, user.id),
+        password: 'wrong-password'
+      })
+      .expect(function(res) {
+        var token = JSON.parse(res.text);
+        token.should.have.property('access_token').with.length(40);
+        token.should.have.property('expires_in');
+        token.token_type.should.equal('bearer');
+      })
+      .expect(200, done);
+  });
+
+  it('should pick auth-backend based on the client id (deny all)', function(done) {
+    request(app)
+      .post('/oauth/token')
+      .auth(clientId3, client3.secret)
+      .type('form')
+      .send({
+        grant_type: 'password',
+        username: userEncode(user.libraryId, user.id),
+        password: password
+      })
+      // TODO: This shouldn't be a '400', but the oauth-library is at fault here. Make it return the proper error code..
+      .expect(400, done);
   });
 });

--- a/src/expressapp.js
+++ b/src/expressapp.js
@@ -8,6 +8,7 @@ import basicAuth from 'basic-auth';
 import redis from 'redis';
 import moment from 'moment';
 import _ from 'lodash';
+import url from 'url';
 import {log} from './utils';
 import Model from './oauth/twolevel.model.js';
 // import throttle from './throttle/throttle.middleware.js';
@@ -210,6 +211,13 @@ export function createOAuthApp(config = {}) {
         }
       }
     }
+
+    if (typeof req.body.username != 'undefined') {
+      var clientCredentials = basicAuth(req) || {};
+      const user = userDecode(req.body.username);
+      req.body.username = url.format({protocol: clientCredentials.name, host: user.libraryId, auth: user.id, slashes: true});
+    }
+
     next();
   });
   app.post('/oauth/token', app.oauth.grant());

--- a/src/migrations/20160915044742-add-auth-to-clients.js
+++ b/src/migrations/20160915044742-add-auth-to-clients.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  up: function (queryInterface, Sequelize) {
+    return queryInterface.addColumn('clients', 'auth', {
+      type: Sequelize.TEXT,
+      allowNull: true
+
+    })
+  },
+
+  down: function (queryInterface, Sequelize) { // eslint-disable-line no-unused-vars
+    return queryInterface.removeColumn('clients', 'auth');
+  }
+};

--- a/src/models/clients.js
+++ b/src/models/clients.js
@@ -15,7 +15,8 @@ module.exports = function(sequelize, DataTypes) {
     },
     name: DataTypes.TEXT,
     config: DataTypes.JSONB,
-    contact: DataTypes.JSONB
+    contact: DataTypes.JSONB,
+    auth: DataTypes.TEXT,
   });
   return clients;
 };

--- a/src/oauth/twolevel.model.js
+++ b/src/oauth/twolevel.model.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import lodash from 'lodash';
 import url from 'url';
 import {log, userEncode} from '../utils';
 // import Throttler from '../throttle/throttle.js';
@@ -63,37 +64,53 @@ export class Model {
     const username = userEncode(providedUser.host, providedUser.auth);
     const clientId = providedUser.protocol.substring(0, providedUser.protocol.length-1); // God know why the protocol includes the ':'
 
-    var storePasswordsInRedisClient = this.app.get('storePasswordsInRedisClient');
+    const storePasswordsInRedisClient = this.app.get('storePasswordsInRedisClient');
+    const stores = this.app.get('stores');
+    const auth = this.app.get('auth');
 
-    this.app.get('stores').userStore.getUser(username, password)
-      .then((user) => {
-        if (user) {
-          if (typeof storePasswordsInRedisClient !== 'undefined') {
-            storePasswordsInRedisClient.set(username, password, (err, res) => { // eslint-disable-line no-unused-vars
-              if (err) {
-                callback(new Error('I\'m a teapot'), null);
+    stores.clientStore.get(clientId)
+      .then((client) => {
+        const authBackend = client.auth || 'default';
+        log.debug('Using auth backend ' + authBackend, {authBackend: authBackend});
+
+        if (!lodash.has(auth, authBackend)) {
+          return callback(new Error('Requested auth-backend missing.'), null);
+        }
+
+        auth[authBackend].getUser(username, password)
+          .then((user) => {
+            if (user) {
+              if (typeof storePasswordsInRedisClient !== 'undefined') {
+                storePasswordsInRedisClient.set(username, password, (err, res) => { // eslint-disable-line no-unused-vars
+                  if (err) {
+                    callback(new Error('I\'m a teapot'), null);
+                  }
+                  else {
+                    // success
+                    callback(null, user);
+                  }
+                });
               }
               else {
                 // success
                 callback(null, user);
               }
-            });
-          }
-          else {
-            // success
-            callback(null, user);
-          }
-        }
-        else {
-          // if getUser fails
-          // register username
-          // throttler.registerAuthFailure(username);
-          // and return a non-informative auth error
-          callback(false, null);
-        }
+            }
+            else {
+              // if getUser fails
+              // register username
+              // throttler.registerAuthFailure(username);
+              // and return a non-informative auth error
+              callback(false, null);
+            }
+          })
+          .catch((err) => {
+            callback(err, null);
+          });
       })
       .catch((err) => {
-        callback(err, null);
+        log.info('model.getClient failure', {clientId: clientId, err: err});
+        callback(null, false);
       });
   }
 

--- a/src/oauth/twolevel.model.js
+++ b/src/oauth/twolevel.model.js
@@ -1,6 +1,7 @@
 'use strict';
 
-import {log} from '../utils';
+import url from 'url';
+import {log, userEncode} from '../utils';
 // import Throttler from '../throttle/throttle.js';
 
 /**
@@ -57,7 +58,11 @@ export class Model {
     }
   }
 
-  getUser (username, password, callback) {
+  getUser (encodedUser, password, callback) {
+    const providedUser = url.parse(encodedUser);
+    const username = userEncode(providedUser.host, providedUser.auth);
+    const clientId = providedUser.protocol.substring(0, providedUser.protocol.length-1); // God know why the protocol includes the ':'
+
     var storePasswordsInRedisClient = this.app.get('storePasswordsInRedisClient');
 
     this.app.get('stores').userStore.getUser(username, password)

--- a/src/oauth/userstore/__tests__/deny-all.test.js
+++ b/src/oauth/userstore/__tests__/deny-all.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import Chance from 'chance';
+import UserStore from '../deny-all';
+import {userEncode} from '../../../utils';
+
+chai.use(chaiAsPromised);
+chai.should();
+
+describe('deny-all', function () {
+  var chance = new Chance();
+  var userStore = null;
+  var username = null;
+  var password = null;
+
+  before(function () {
+    userStore = new UserStore();
+    var libraryId = chance.word({length: 6});
+    var userId = chance.word({length: 10});
+    username = userEncode(libraryId, userId);
+    password = chance.word({length: 10});
+  });
+
+  it('should respond to ping', function () {
+    return userStore.ping().should.be.fulfilled;
+  });
+
+  it('should store an user', function () {
+    return userStore.storeUser(username, password).should.be.fulfilled;
+  });
+
+  it('should fail to retrieve the newly stored user', function () {
+    return userStore.getUser(username, password).should.eventually.deep.equal(false);
+  });
+});

--- a/src/oauth/userstore/__tests__/userstore.test.js
+++ b/src/oauth/userstore/__tests__/userstore.test.js
@@ -4,6 +4,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import Chance from 'chance';
 import InmemoryUserStore from '../inmemory';
+import AllowAllUserStore from '../allow-all';
 import {userEncode} from '../../../utils';
 
 chai.use(chaiAsPromised);
@@ -12,6 +13,9 @@ chai.should();
 var backends = {
   inmemory: () => {
     return new InmemoryUserStore();
+  },
+  allowAll: () => {
+    return new AllowAllUserStore()
   }
 };
 

--- a/src/oauth/userstore/allow-all.js
+++ b/src/oauth/userstore/allow-all.js
@@ -1,0 +1,22 @@
+'use strict';
+
+export default class UserStore {
+  static requiredOptions() {
+    return [];
+  }
+
+  constructor(stores, config) { // eslint-disable-line no-unused-vars
+  }
+
+  ping() {
+    return Promise.resolve();
+  }
+
+  storeUser (username, password) { // eslint-disable-line no-unused-vars
+    return Promise.resolve();
+  }
+
+  getUser (username, password) { // eslint-disable-line no-unused-vars
+    return Promise.resolve({id: username});
+  }
+}

--- a/src/oauth/userstore/deny-all.js
+++ b/src/oauth/userstore/deny-all.js
@@ -1,0 +1,22 @@
+'use strict';
+
+export default class UserStore {
+  static requiredOptions() {
+    return [];
+  }
+
+  constructor(stores, config) { // eslint-disable-line no-unused-vars
+  }
+
+  ping() {
+    return Promise.resolve();
+  }
+
+  storeUser (username, password) { // eslint-disable-line no-unused-vars
+    return Promise.resolve();
+  }
+
+  getUser (username, password) { // eslint-disable-line no-unused-vars
+    return Promise.resolve(false);
+  }
+}

--- a/src/oauth/userstore/inmemory.js
+++ b/src/oauth/userstore/inmemory.js
@@ -52,6 +52,6 @@ export default class UserStore {
       return Promise.resolve({id: username});
     }
 
-    return Promise.reject(new Error('invalid username or password'));
+    return Promise.resolve(false);
   }
 }


### PR DESCRIPTION
fixes #170 

Warning: This change makes Smaug incompatible with the current config format!

The old "userStore"-section has been replaced with an auth-section, that as a minimum should contain something like:
```
  "auth": {
    "default" : {
      "backend": "inmemory",
      "config": {
        "users": {
          "donald@010101": "duck"
        }
      }
    },
    "allow-all": {
      "backend": "allow-all",
      "config": {}
    },
    "deny-all": {
      "backend": "deny-all",
      "config": {}
    }
  }
```

Do notice that the configuration of a single backend hasn't changed, only the nesting has.

This PR does NOT include the required UI to set/change auth-settings for a client, so it has to be done with SQL like this:
`update clients set auth = 'deny-all' where id = '...';`